### PR TITLE
remove npm test from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_script:
 script:
    - npm install
    - npm run lint
-   - npm test
 branches:
   only:
     - master


### PR DESCRIPTION
There are currently no test so we are just skipping this for the time
being.