### PR TITLE
add a simply way for generating a html report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+license.html

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ licenses to be retrieved and reported in xml and html format.
       --file     file to store the licence information in                   [string]
       --all      will list all production licenses for all modules  [default: false]
       --silent   hides the console output                           [default: false]
+      --html     outputs the license in html format to license.html [default: false]
       --help     Show help                                                 [boolean]
 
 ## Example output

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,6 +37,11 @@ module.exports = function run(options) {
       if (options.file) {
         fs.writeFileSync(options.file, report);
       }
+
+      if (options.html) {
+        let html = require('../lib/html.js');
+        fs.writeFileSync('license.html', html.parse(licenseInfo));
+      }
     }
   });
 };

--- a/bin/licenser
+++ b/bin/licenser
@@ -9,7 +9,7 @@ yargs
   .version(require('../package.json').version)
   .usage('Usage: $0 /path/to/project [options]')
   .option('file', {
-    describe: 'file to store the licence information in',
+    describe: 'file to store the license information in',
     type: 'string'
   }) 
   .option('all', {
@@ -20,6 +20,10 @@ yargs
     describe: 'hides the console output',
     default: false 
   })
+  .option('html', {
+    describe: 'outputs the license in html format to license.html',
+    default: false
+  })
   .help();
 
 const argv = yargs.argv;
@@ -29,7 +33,8 @@ var options = {
   alldeps: argv.all,
   directory: argv._[0],
   silent: argv.silent,
-  file: argv.file
+  file: argv.file,
+  html: argv.html
 };
 
 if (!options.directory || options.directory === '.') {

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const mustache = require("mustache");
+const mustache = require('mustache');
 const fs = require('fs');
 const template = fs.readFileSync('lib/template.html', 'utf8');
 
-function parse(object) {
+function parse (object) {
   return mustache.to_html(template, object);
 }
 

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const mustache = require("mustache");
+const fs = require('fs');
+const template = fs.readFileSync('lib/template.html', 'utf8');
+
+function parse(object) {
+  return mustache.to_html(template, object);
+}
+
+module.exports = { parse };

--- a/lib/template.html
+++ b/lib/template.html
@@ -1,0 +1,6 @@
+{{#licenses.license}}
+<b>{{name}}</b>
+<b>{{version}}</b>
+<b>{{licenses}}</b>
+<b>{{file}}</b>
+{{/licenses.license}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,6 +1363,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mustache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
+      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
+    },
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "decomment": "^0.8.8",
     "js2xmlparser": "^3.0.0",
     "license-checker": "^11.0.0",
+    "mustache": "^2.3.0",
     "node-builtins": "^0.1.1",
     "yargs": "^8.0.2"
   },

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -8,8 +8,8 @@ test('Should generate html from xml', (t) => {
   const licenseInfo = {
     licenses: {
       license: [
-        {name: "test1", version: '1.0', licenses: 'MIT', file: '...'},
-        {name: "test2", version: '1.2', licenses: 'MIT', file: '...'}
+        {name: 'test1', version: '1.0', licenses: 'MIT', file: '...'},
+        {name: 'test2', version: '1.2', licenses: 'MIT', file: '...'}
       ]
     }
   };

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const test = require('tape');
+const html = require('../lib/html.js');
+
+test('Should generate html from xml', (t) => {
+  t.plan(1);
+  const licenseInfo = {
+    licenses: {
+      license: [
+        {name: "test1", version: '1.0', licenses: 'MIT', file: '...'},
+        {name: "test2", version: '1.2', licenses: 'MIT', file: '...'}
+      ]
+    }
+  };
+  const output = html.parse(licenseInfo);
+  t.equal(output.trim(), '<b>test1</b>\n<b>1.0</b>\n<b>MIT</b>\n<b>...</b>\n<b>test2</b>\n<b>1.2</b>\n<b>MIT</b>\n<b>...</b>');
+  t.end();
+});


### PR DESCRIPTION
This commit adds a mustache template which currently only has an
iteration of the licenses. When we have the actual html template we can
move and itertion to the proper location and add additional information
required.