### PR TITLE
src: update html template with Red Hat html

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,7 +12,8 @@ module.exports = function run(options) {
       const projectName = require(options.directory + "/package.json").name;
       const projectDeps = require(options.directory + "/package.json").dependencies;
 
-      let licenseInfo = {
+      let project = {
+        name: projectName,
         licenses: {
           license: []
         }
@@ -25,11 +26,11 @@ module.exports = function run(options) {
       } else {
         for (var name in projectDeps) {
           const npmVersion = asNpmVersion(name, projectDeps[name]);
-          add(licenseInfo, npmVersion, allDeps);
+          add(project.licenses, npmVersion, allDeps);
         }
       }
 
-      const report = xml.parse(projectName, licenseInfo);
+      const report = xml.parse(projectName, project.licenses);
       if (!options.silent) {
         console.log(report);
       }
@@ -40,17 +41,19 @@ module.exports = function run(options) {
 
       if (options.html) {
         let html = require('../lib/html.js');
-        fs.writeFileSync('license.html', html.parse(licenseInfo));
+        html.parse(project).then(output => {
+          fs.writeFileSync('license.html', output);
+        });
       }
     }
   });
 };
 
-function add(licenseInfo, npmVersion, allDeps) {
+function add(licenses, npmVersion, allDeps) {
   if (allDeps.hasOwnProperty(npmVersion)) {
     const nameVersion = fromNpmVersion(npmVersion);
     const info = allDeps[npmVersion];
-    licenseInfo.licenses.license.push(entry(info, nameVersion)); 
+    licenses.license.push(entry(info, nameVersion));
   }
 }
 

--- a/lib/licenses.css
+++ b/lib/licenses.css
@@ -1,0 +1,22 @@
+table {
+    border-collapse: collapse;
+}
+
+table, th, td {
+    border: 1px solid navy;
+}
+
+th {
+    text-align: left;
+    background-color: #BCC6CC;
+
+}
+
+th, td {
+    padding: 2px;
+    text-align: left;
+}
+
+tr:nth-child(even) {
+    background-color: #f2f2f2;
+}

--- a/lib/template.html
+++ b/lib/template.html
@@ -1,6 +1,27 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<link rel="stylesheet" type="text/css" href="licenses.css">
+</head>
+<body>
+<h2>{{name}}</h2>
+<table>
+<tr>
+<th>Package Group</th>
+<th>Package Artifact</th>
+<th>Package Version</th>
+<th>Remote Licenses</th>
+<th>Local Licenses</th>
+</tr>
 {{#licenses.license}}
-<b>{{name}}</b>
-<b>{{version}}</b>
-<b>{{licenses}}</b>
-<b>{{file}}</b>
+<tr>
+<td>{{name}}</td>
+<td>N/A</td>
+<td>{{version}}</td>
+<td>{{licenses}}</td>
+<td>{{file}}</td>
+</tr>
 {{/licenses.license}}
+</table>
+</body>
+</html>

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -5,7 +5,8 @@ const html = require('../lib/html.js');
 
 test('Should generate html from xml', (t) => {
   t.plan(1);
-  const licenseInfo = {
+  const project = {
+    name: 'testProject',
     licenses: {
       license: [
         {name: 'test1', version: '1.0', licenses: 'MIT', file: '...'},
@@ -13,9 +14,40 @@ test('Should generate html from xml', (t) => {
       ]
     }
   };
-  html.parse(licenseInfo)
-  .then(output => {
-    t.equal(output, '<b>test1</b>\n<b>1.0</b>\n<b>MIT</b>\n<b>...</b>\n<b>test2</b>\n<b>1.2</b>\n<b>MIT</b>\n<b>...</b>');
+  html.parse(project).then(output => {
+    const expected = String.raw`<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<link rel="stylesheet" type="text/css" href="licenses.css">
+</head>
+<body>
+<h2>testProject</h2>
+<table>
+<tr>
+<th>Package Group</th>
+<th>Package Artifact</th>
+<th>Package Version</th>
+<th>Remote Licenses</th>
+<th>Local Licenses</th>
+</tr>
+<tr>
+<td>test1</td>
+<td>N/A</td>
+<td>1.0</td>
+<td>MIT</td>
+<td>...</td>
+</tr>
+<tr>
+<td>test2</td>
+<td>N/A</td>
+<td>1.2</td>
+<td>MIT</td>
+<td>...</td>
+</tr>
+</table>
+</body>
+</html>`;
+    t.equal(output, expected);
     t.end();
   })
   .catch(e => {


### PR DESCRIPTION
Currently the template is just a basic mustache example to verify that
the iteration of licenses was done properly. This commit adds a proper
html template using an example of a real Red Hat license html.