### PR TITLE
src: add xml merging support (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,23 @@ licenses to be retrieved and reported in xml and html format.
     Usage: bin/licenser /path/to/project [options]
 
     Options:
-      --version  Show version number                                       [boolean]
-      --file     file to store the licence information in                   [string]
-      --all      will list all production licenses for all modules  [default: false]
-      --silent   hides the console output                           [default: false]
-      --html     outputs the license in html format to license.html [default: false]
-      --whitelist  file containing licenses that are whitelisted    [default: false]
-      --help     Show help                                                 [boolean]
+    --version             Show version number                            [boolean]
+    --file                file to store the license information in        [string]
+    --all                 will list all production licenses for all modules
+                                                                  [default: false]
+    --silent              hides the console output                [default: false]
+    --html                outputs the license in html format to license.html
+                                                                  [default: false]
+    --whitelist           file containing licenses that are whitelisted
+                                                                  [default: false]
+    --merge               merge license.xml files                 [default: false]
+    --merge-product-name  the name the product which the license.xml are part of
+                                                                  [default: false]
+    --merge-license-xmls  a comma separated list of license.xml files to merge
+                                                                  [default: false]
+    --merge-output        file to write the merged license info to
+    --help                Show help                                      [boolean]
+
 
 ## Example output
 
@@ -322,6 +332,580 @@ licenses to be retrieved and reported in xml and html format.
         </license>
     </licenses>
 </licenser>
+```
+## XML merging example
+The intention for this functionality is to be able to create an xml file that contains all the liceses for a product (made up of one or more projects).
+
+    $ ./bin/licenser --merge --merge-product-name="UberProject" --merge-license-xmls="license1.xml, license2.xml" --merge-output="merged.xml" --silent
+
+    $ cat merged.xml
+```xml
+<?xml version='1.0'?>
+<UberProject>
+    <project>
+        <licenser>
+            <license>
+                <name>js2xmlparser</name>
+                <version>3.0.0</version>
+                <licenses>Apache-2.0</licenses>
+                <file>Apache License
+                        ==============
+                        
+                        _Version 2.0, January 2004_  
+                        _&amp;lt;&lt;http://www.apache.org/licenses/>&amp;gt;_
+                        
+                        ### Terms and Conditions for use, reproduction, and distribution
+                        
+                        #### 1. Definitions
+                        
+                        “License” shall mean the terms and conditions for use, reproduction, and
+                        distribution as defined by Sections 1 through 9 of this document.
+                        
+                        “Licensor” shall mean the copyright owner or entity authorized by the copyright
+                        owner that is granting the License.
+                        
+                        “Legal Entity” shall mean the union of the acting entity and all other entities
+                        that control, are controlled by, or are under common control with that entity.
+                        For the purposes of this definition, “control” means **(i)** the power, direct or
+                        indirect, to cause the direction or management of such entity, whether by
+                        contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+                        outstanding shares, or **(iii)** beneficial ownership of such entity.
+                        
+                        “You” (or “Your”) shall mean an individual or Legal Entity exercising
+                        permissions granted by this License.
+                        
+                        “Source” form shall mean the preferred form for making modifications, including
+                        but not limited to software source code, documentation source, and configuration
+                        files.
+                        
+                        “Object” form shall mean any form resulting from mechanical transformation or
+                        translation of a Source form, including but not limited to compiled object code,
+                        generated documentation, and conversions to other media types.
+                        
+                        “Work” shall mean the work of authorship, whether in Source or Object form, made
+                        available under the License, as indicated by a copyright notice that is included
+                        in or attached to the work (an example is provided in the Appendix below).
+                        
+                        “Derivative Works” shall mean any work, whether in Source or Object form, that
+                        is based on (or derived from) the Work and for which the editorial revisions,
+                        annotations, elaborations, or other modifications represent, as a whole, an
+                        original work of authorship. For the purposes of this License, Derivative Works
+                        shall not include works that remain separable from, or merely link (or bind by
+                        name) to the interfaces of, the Work and Derivative Works thereof.
+                        
+                        “Contribution” shall mean any work of authorship, including the original version
+                        of the Work and any modifications or additions to that Work or Derivative Works
+                        thereof, that is intentionally submitted to Licensor for inclusion in the Work
+                        by the copyright owner or by an individual or Legal Entity authorized to submit
+                        on behalf of the copyright owner. For the purposes of this definition,
+                        “submitted” means any form of electronic, verbal, or written communication sent
+                        to the Licensor or its representatives, including but not limited to
+                        communication on electronic mailing lists, source code control systems, and
+                        issue tracking systems that are managed by, or on behalf of, the Licensor for
+                        the purpose of discussing and improving the Work, but excluding communication
+                        that is conspicuously marked or otherwise designated in writing by the copyright
+                        owner as “Not a Contribution.”
+                        
+                        “Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+                        of whom a Contribution has been received by Licensor and subsequently
+                        incorporated within the Work.
+                        
+                        #### 2. Grant of Copyright License
+                        
+                        Subject to the terms and conditions of this License, each Contributor hereby
+                        grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+                        irrevocable copyright license to reproduce, prepare Derivative Works of,
+                        publicly display, publicly perform, sublicense, and distribute the Work and such
+                        Derivative Works in Source or Object form.
+                        
+                        #### 3. Grant of Patent License
+                        
+                        Subject to the terms and conditions of this License, each Contributor hereby
+                        grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+                        irrevocable (except as stated in this section) patent license to make, have
+                        made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+                        such license applies only to those patent claims licensable by such Contributor
+                        that are necessarily infringed by their Contribution(s) alone or by combination
+                        of their Contribution(s) with the Work to which such Contribution(s) was
+                        submitted. If You institute patent litigation against any entity (including a
+                        cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+                        Contribution incorporated within the Work constitutes direct or contributory
+                        patent infringement, then any patent licenses granted to You under this License
+                        for that Work shall terminate as of the date such litigation is filed.
+                        
+                        #### 4. Redistribution
+                        
+                        You may reproduce and distribute copies of the Work or Derivative Works thereof
+                        in any medium, with or without modifications, and in Source or Object form,
+                        provided that You meet the following conditions:
+                        
+                        * **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+                        this License; and
+                        * **(b)** You must cause any modified files to carry prominent notices stating that You
+                        changed the files; and
+                        * **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+                        all copyright, patent, trademark, and attribution notices from the Source form
+                        of the Work, excluding those notices that do not pertain to any part of the
+                        Derivative Works; and
+                        * **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+                        Derivative Works that You distribute must include a readable copy of the
+                        attribution notices contained within such NOTICE file, excluding those notices
+                        that do not pertain to any part of the Derivative Works, in at least one of the
+                        following places: within a NOTICE text file distributed as part of the
+                        Derivative Works; within the Source form or documentation, if provided along
+                        with the Derivative Works; or, within a display generated by the Derivative
+                        Works, if and wherever such third-party notices normally appear. The contents of
+                        the NOTICE file are for informational purposes only and do not modify the
+                        License. You may add Your own attribution notices within Derivative Works that
+                        You distribute, alongside or as an addendum to the NOTICE text from the Work,
+                        provided that such additional attribution notices cannot be construed as
+                        modifying the License.
+                        
+                        You may add Your own copyright statement to Your modifications and may provide
+                        additional or different license terms and conditions for use, reproduction, or
+                        distribution of Your modifications, or for any such Derivative Works as a whole,
+                        provided Your use, reproduction, and distribution of the Work otherwise complies
+                        with the conditions stated in this License.
+                        
+                        #### 5. Submission of Contributions
+                        
+                        Unless You explicitly state otherwise, any Contribution intentionally submitted
+                        for inclusion in the Work by You to the Licensor shall be under the terms and
+                        conditions of this License, without any additional terms or conditions.
+                        Notwithstanding the above, nothing herein shall supersede or modify the terms of
+                        any separate license agreement you may have executed with Licensor regarding
+                        such Contributions.
+                        
+                        #### 6. Trademarks
+                        
+                        This License does not grant permission to use the trade names, trademarks,
+                        service marks, or product names of the Licensor, except as required for
+                        reasonable and customary use in describing the origin of the Work and
+                        reproducing the content of the NOTICE file.
+                        
+                        #### 7. Disclaimer of Warranty
+                        
+                        Unless required by applicable law or agreed to in writing, Licensor provides the
+                        Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+                        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+                        including, without limitation, any warranties or conditions of TITLE,
+                        NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+                        solely responsible for determining the appropriateness of using or
+                        redistributing the Work and assume any risks associated with Your exercise of
+                        permissions under this License.
+                        
+                        #### 8. Limitation of Liability
+                        
+                        In no event and under no legal theory, whether in tort (including negligence),
+                        contract, or otherwise, unless required by applicable law (such as deliberate
+                        and grossly negligent acts) or agreed to in writing, shall any Contributor be
+                        liable to You for damages, including any direct, indirect, special, incidental,
+                        or consequential damages of any character arising as a result of this License or
+                        out of the use or inability to use the Work (including but not limited to
+                        damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+                        any and all other commercial damages or losses), even if such Contributor has
+                        been advised of the possibility of such damages.
+                        
+                        #### 9. Accepting Warranty or Additional Liability
+                        
+                        While redistributing the Work or Derivative Works thereof, You may choose to
+                        offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+                        other liability obligations and/or rights consistent with this License. However,
+                        in accepting such obligations, You may act only on Your own behalf and on Your
+                        sole responsibility, not on behalf of any other Contributor, and only if You
+                        agree to indemnify, defend, and hold each Contributor harmless for any liability
+                        incurred by, or claims asserted against, such Contributor by reason of your
+                        accepting any such warranty or additional liability.
+                        
+                        _END OF TERMS AND CONDITIONS_
+                        
+                        ### APPENDIX: How to apply the Apache License to your work
+                        
+                        To apply the Apache License to your work, attach the following boilerplate
+                        notice, with the fields enclosed by brackets `[]` replaced with your own
+                        identifying information. (Don't include the brackets!) The text should be
+                        enclosed in the appropriate comment syntax for the file format. We also
+                        recommend that a file or class name and description of purpose be included on
+                        the same “printed page” as the copyright notice for easier identification within
+                        third-party archives.
+                        
+                            Copyright [yyyy] [name of copyright owner]
+                            
+                            Licensed under the Apache License, Version 2.0 (the "License");
+                            you may not use this file except in compliance with the License.
+                            You may obtain a copy of the License at
+                            
+                              http://www.apache.org/licenses/LICENSE-2.0
+                            
+                            Unless required by applicable law or agreed to in writing, software
+                            distributed under the License is distributed on an "AS IS" BASIS,
+                            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                            See the License for the specific language governing permissions and
+                            limitations under the License.
+                        </file>
+            </license>
+            <license>
+                <name>license-checker</name>
+                <version>11.0.0</version>
+                <licenses>BSD-3-Clause</licenses>
+                <file>Copyright 2012 Yahoo! Inc.
+                        All rights reserved.
+                        
+                        Redistribution and use in source and binary forms, with or without
+                        modification, are permitted provided that the following conditions are met:
+                            * Redistributions of source code must retain the above copyright
+                              notice, this list of conditions and the following disclaimer.
+                            * Redistributions in binary form must reproduce the above copyright
+                              notice, this list of conditions and the following disclaimer in the
+                              documentation and/or other materials provided with the distribution.
+                            * Neither the name of the Yahoo! Inc. nor the
+                              names of its contributors may be used to endorse or promote products
+                              derived from this software without specific prior written permission.
+                        
+                        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+                        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+                        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                        DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+                        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+                        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+                        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+                        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+                        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                        
+                        </file>
+            </license>
+            <license>
+                <name>mustache</name>
+                <version>2.3.0</version>
+                <licenses>MIT</licenses>
+                <file>The MIT License
+                        
+                        Copyright (c) 2009 Chris Wanstrath (Ruby)
+                        Copyright (c) 2010-2014 Jan Lehnardt (JavaScript)
+                        Copyright (c) 2010-2015 The mustache.js community
+                        
+                        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+                        
+                        The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+                        
+                        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+                        </file>
+            </license>
+            <license>
+                <name>xml2js</name>
+                <version>0.4.17</version>
+                <licenses>MIT</licenses>
+                <file>Copyright 2010, 2011, 2012, 2013. All rights reserved.
+                        
+                        Permission is hereby granted, free of charge, to any person obtaining a copy
+                        of this software and associated documentation files (the "Software"), to
+                        deal in the Software without restriction, including without limitation the
+                        rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+                        sell copies of the Software, and to permit persons to whom the Software is
+                        furnished to do so, subject to the following conditions:
+                        
+                        The above copyright notice and this permission notice shall be included in
+                        all copies or substantial portions of the Software.
+                        
+                        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+                        FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+                        IN THE SOFTWARE.
+                        </file>
+            </license>
+            <license>
+                <name>yargs</name>
+                <version>8.0.2</version>
+                <licenses>MIT</licenses>
+                <file>Copyright 2010 James Halliday (mail@substack.net)
+                        Modified work Copyright 2014 Contributors (ben@npmjs.com)
+                        
+                        This project is free software released under the MIT/X11 license:
+                        
+                        Permission is hereby granted, free of charge, to any person obtaining a copy
+                        of this software and associated documentation files (the "Software"), to deal
+                        in the Software without restriction, including without limitation the rights
+                        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                        copies of the Software, and to permit persons to whom the Software is
+                        furnished to do so, subject to the following conditions:
+                        
+                        The above copyright notice and this permission notice shall be included in
+                        all copies or substantial portions of the Software.
+                        
+                        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+                        THE SOFTWARE.
+                        </file>
+            </license>
+        </licenser>
+    </project>
+    <project>
+        <szero>
+            <license>
+                <name>commander</name>
+                <version>2.9.0</version>
+                <licenses>MIT</licenses>
+                <file>(The MIT License)
+                        
+                        Copyright (c) 2011 TJ Holowaychuk &lt;tj@vision-media.ca>
+                        
+                        Permission is hereby granted, free of charge, to any person obtaining
+                        a copy of this software and associated documentation files (the
+                        'Software'), to deal in the Software without restriction, including
+                        without limitation the rights to use, copy, modify, merge, publish,
+                        distribute, sublicense, and/or sell copies of the Software, and to
+                        permit persons to whom the Software is furnished to do so, subject to
+                        the following conditions:
+                        
+                        The above copyright notice and this permission notice shall be
+                        included in all copies or substantial portions of the Software.
+                        
+                        THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+                        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+                        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+                        IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+                        CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+                        TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+                        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+                        </file>
+            </license>
+            <license>
+                <name>node-builtins</name>
+                <version>0.1.1</version>
+                <licenses>Apache-2.0</licenses>
+                <file>
+                        Copyright 2016 Red Hat, Inc.
+                        
+                        Licensed under the Apache License, Version 2.0 (the "License");
+                        you may not use this file except in compliance with the License.
+                        You may obtain a copy of the License at
+                        
+                        http://www.apache.org/licenses/LICENSE-2.0
+                        Unless required by applicable law or agreed to in writing, software
+                        distributed under the License is distributed on an "AS IS" BASIS,
+                        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                        See the License for the specific language governing permissions and
+                        limitations under the License.
+                        </file>
+            </license>
+            <license>
+                <name>roi</name>
+                <version>0.15.0</version>
+                <licenses>Apache-2.0</licenses>
+                <file>                                 Apache License
+                                                   Version 2.0, January 2004
+                                                http://www.apache.org/licenses/
+                        
+                           TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                        
+                           1. Definitions.
+                        
+                              "License" shall mean the terms and conditions for use, reproduction,
+                              and distribution as defined by Sections 1 through 9 of this document.
+                        
+                              "Licensor" shall mean the copyright owner or entity authorized by
+                              the copyright owner that is granting the License.
+                        
+                              "Legal Entity" shall mean the union of the acting entity and all
+                              other entities that control, are controlled by, or are under common
+                              control with that entity. For the purposes of this definition,
+                              "control" means (i) the power, direct or indirect, to cause the
+                              direction or management of such entity, whether by contract or
+                              otherwise, or (ii) ownership of fifty percent (50%) or more of the
+                              outstanding shares, or (iii) beneficial ownership of such entity.
+                        
+                              "You" (or "Your") shall mean an individual or Legal Entity
+                              exercising permissions granted by this License.
+                        
+                              "Source" form shall mean the preferred form for making modifications,
+                              including but not limited to software source code, documentation
+                              source, and configuration files.
+                        
+                              "Object" form shall mean any form resulting from mechanical
+                              transformation or translation of a Source form, including but
+                              not limited to compiled object code, generated documentation,
+                              and conversions to other media types.
+                        
+                              "Work" shall mean the work of authorship, whether in Source or
+                              Object form, made available under the License, as indicated by a
+                              copyright notice that is included in or attached to the work
+                              (an example is provided in the Appendix below).
+                        
+                              "Derivative Works" shall mean any work, whether in Source or Object
+                              form, that is based on (or derived from) the Work and for which the
+                              editorial revisions, annotations, elaborations, or other modifications
+                              represent, as a whole, an original work of authorship. For the purposes
+                              of this License, Derivative Works shall not include works that remain
+                              separable from, or merely link (or bind by name) to the interfaces of,
+                              the Work and Derivative Works thereof.
+                        
+                              "Contribution" shall mean any work of authorship, including
+                              the original version of the Work and any modifications or additions
+                              to that Work or Derivative Works thereof, that is intentionally
+                              submitted to Licensor for inclusion in the Work by the copyright owner
+                              or by an individual or Legal Entity authorized to submit on behalf of
+                              the copyright owner. For the purposes of this definition, "submitted"
+                              means any form of electronic, verbal, or written communication sent
+                              to the Licensor or its representatives, including but not limited to
+                              communication on electronic mailing lists, source code control systems,
+                              and issue tracking systems that are managed by, or on behalf of, the
+                              Licensor for the purpose of discussing and improving the Work, but
+                              excluding communication that is conspicuously marked or otherwise
+                              designated in writing by the copyright owner as "Not a Contribution."
+                        
+                              "Contributor" shall mean Licensor and any individual or Legal Entity
+                              on behalf of whom a Contribution has been received by Licensor and
+                              subsequently incorporated within the Work.
+                        
+                           2. Grant of Copyright License. Subject to the terms and conditions of
+                              this License, each Contributor hereby grants to You a perpetual,
+                              worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+                              copyright license to reproduce, prepare Derivative Works of,
+                              publicly display, publicly perform, sublicense, and distribute the
+                              Work and such Derivative Works in Source or Object form.
+                        
+                           3. Grant of Patent License. Subject to the terms and conditions of
+                              this License, each Contributor hereby grants to You a perpetual,
+                              worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+                              (except as stated in this section) patent license to make, have made,
+                              use, offer to sell, sell, import, and otherwise transfer the Work,
+                              where such license applies only to those patent claims licensable
+                              by such Contributor that are necessarily infringed by their
+                              Contribution(s) alone or by combination of their Contribution(s)
+                              with the Work to which such Contribution(s) was submitted. If You
+                              institute patent litigation against any entity (including a
+                              cross-claim or counterclaim in a lawsuit) alleging that the Work
+                              or a Contribution incorporated within the Work constitutes direct
+                              or contributory patent infringement, then any patent licenses
+                              granted to You under this License for that Work shall terminate
+                              as of the date such litigation is filed.
+                        
+                           4. Redistribution. You may reproduce and distribute copies of the
+                              Work or Derivative Works thereof in any medium, with or without
+                              modifications, and in Source or Object form, provided that You
+                              meet the following conditions:
+                        
+                              (a) You must give any other recipients of the Work or
+                                  Derivative Works a copy of this License; and
+                        
+                              (b) You must cause any modified files to carry prominent notices
+                                  stating that You changed the files; and
+                        
+                              (c) You must retain, in the Source form of any Derivative Works
+                                  that You distribute, all copyright, patent, trademark, and
+                                  attribution notices from the Source form of the Work,
+                                  excluding those notices that do not pertain to any part of
+                                  the Derivative Works; and
+                        
+                              (d) If the Work includes a "NOTICE" text file as part of its
+                                  distribution, then any Derivative Works that You distribute must
+                                  include a readable copy of the attribution notices contained
+                                  within such NOTICE file, excluding those notices that do not
+                                  pertain to any part of the Derivative Works, in at least one
+                                  of the following places: within a NOTICE text file distributed
+                                  as part of the Derivative Works; within the Source form or
+                                  documentation, if provided along with the Derivative Works; or,
+                                  within a display generated by the Derivative Works, if and
+                                  wherever such third-party notices normally appear. The contents
+                                  of the NOTICE file are for informational purposes only and
+                                  do not modify the License. You may add Your own attribution
+                                  notices within Derivative Works that You distribute, alongside
+                                  or as an addendum to the NOTICE text from the Work, provided
+                                  that such additional attribution notices cannot be construed
+                                  as modifying the License.
+                        
+                              You may add Your own copyright statement to Your modifications and
+                              may provide additional or different license terms and conditions
+                              for use, reproduction, or distribution of Your modifications, or
+                              for any such Derivative Works as a whole, provided Your use,
+                              reproduction, and distribution of the Work otherwise complies with
+                              the conditions stated in this License.
+                        
+                           5. Submission of Contributions. Unless You explicitly state otherwise,
+                              any Contribution intentionally submitted for inclusion in the Work
+                              by You to the Licensor shall be under the terms and conditions of
+                              this License, without any additional terms or conditions.
+                              Notwithstanding the above, nothing herein shall supersede or modify
+                              the terms of any separate license agreement you may have executed
+                              with Licensor regarding such Contributions.
+                        
+                           6. Trademarks. This License does not grant permission to use the trade
+                              names, trademarks, service marks, or product names of the Licensor,
+                              except as required for reasonable and customary use in describing the
+                              origin of the Work and reproducing the content of the NOTICE file.
+                        
+                           7. Disclaimer of Warranty. Unless required by applicable law or
+                              agreed to in writing, Licensor provides the Work (and each
+                              Contributor provides its Contributions) on an "AS IS" BASIS,
+                              WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+                              implied, including, without limitation, any warranties or conditions
+                              of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+                              PARTICULAR PURPOSE. You are solely responsible for determining the
+                              appropriateness of using or redistributing the Work and assume any
+                              risks associated with Your exercise of permissions under this License.
+                        
+                           8. Limitation of Liability. In no event and under no legal theory,
+                              whether in tort (including negligence), contract, or otherwise,
+                              unless required by applicable law (such as deliberate and grossly
+                              negligent acts) or agreed to in writing, shall any Contributor be
+                              liable to You for damages, including any direct, indirect, special,
+                              incidental, or consequential damages of any character arising as a
+                              result of this License or out of the use or inability to use the
+                              Work (including but not limited to damages for loss of goodwill,
+                              work stoppage, computer failure or malfunction, or any and all
+                              other commercial damages or losses), even if such Contributor
+                              has been advised of the possibility of such damages.
+                        
+                           9. Accepting Warranty or Additional Liability. While redistributing
+                              the Work or Derivative Works thereof, You may choose to offer,
+                              and charge a fee for, acceptance of support, warranty, indemnity,
+                              or other liability obligations and/or rights consistent with this
+                              License. However, in accepting such obligations, You may act only
+                              on Your own behalf and on Your sole responsibility, not on behalf
+                              of any other Contributor, and only if You agree to indemnify,
+                              defend, and hold each Contributor harmless for any liability
+                              incurred by, or claims asserted against, such Contributor by reason
+                              of your accepting any such warranty or additional liability.
+                        
+                           END OF TERMS AND CONDITIONS
+                        
+                           APPENDIX: How to apply the Apache License to your work.
+                        
+                              To apply the Apache License to your work, attach the following
+                              boilerplate notice, with the fields enclosed by brackets "{}"
+                              replaced with your own identifying information. (Don't include
+                              the brackets!)  The text should be enclosed in the appropriate
+                              comment syntax for the file format. We also recommend that a
+                              file or class name and description of purpose be included on the
+                              same "printed page" as the copyright notice for easier
+                              identification within third-party archives.
+                        
+                           Copyright {yyyy} {name of copyright owner}
+                        
+                           Licensed under the Apache License, Version 2.0 (the "License");
+                           you may not use this file except in compliance with the License.
+                           You may obtain a copy of the License at
+                        
+                               http://www.apache.org/licenses/LICENSE-2.0
+                        
+                           Unless required by applicable law or agreed to in writing, software
+                           distributed under the License is distributed on an "AS IS" BASIS,
+                           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                           See the License for the specific language governing permissions and
+                           limitations under the License.
+                        </file>
+            </license>
+        </szero>
+    </project>
+</UberProject>
 ```
 
 ## Contributing

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,6 +5,33 @@ const versionHandler = require('../lib/version-handler.js');
 const fs = require('fs');
 
 module.exports = function run (options) {
+  if (options.merge) {
+    if (!options.mergeProductName) {
+      console.error('merge feature requires a product name');
+      process.exit(1);
+    }
+    if (!options.mergeXmls) {
+      console.error('merge feature requires a two or more licence.xml files to merge');
+      process.exit(1);
+    }
+    const xmls = [];
+    options.mergeXmls.split(',').forEach((file) => {
+      xmls.push(fs.readFileSync(file.trim(), 'utf8'));
+    });
+    xml.merge(options.mergeProductName, xmls).then(result => {
+      if (!options.silent) {
+        console.log(result);
+      }
+      if (options.mergeOutput) {
+        fs.writeFileSync(options.mergeOutput, result);
+      }
+    }).catch(e => {
+      console.error(e);
+      process.exit(2);
+    });
+    return;
+  }
+
   checker.init({start: options.directory}, function (err, allDeps) {
     if (err) {
       // Handle error

--- a/bin/licenser
+++ b/bin/licenser
@@ -28,6 +28,21 @@ yargs
     describe: 'file containing licenses that are whitelisted',
     default: false
   })
+  .option('merge', {
+    describe: 'merge license.xml files',
+    default: false
+  })
+  .option('merge-product-name', {
+    describe: 'the name the product which the license.xml are part of',
+    default: false
+  })
+  .option('merge-license-xmls', {
+    describe: 'a comma separated list of license.xml files to merge',
+    default: false
+  })
+  .option('merge-output', {
+    describe: 'file to write the merged license info to',
+  })
   .help();
 
 const argv = yargs.argv;
@@ -39,7 +54,11 @@ var options = {
   silent: argv.silent,
   file: argv.file,
   html: argv.html,
-  whitelist: argv.whitelist
+  whitelist: argv.whitelist,
+  merge: argv.merge,
+  mergeProductName: argv['merge-product-name'],
+  mergeXmls: argv['merge-license-xmls'],
+  mergeOutput: argv['merge-output']
 };
 
 if (!options.directory || options.directory === '.') {

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -1,9 +1,59 @@
 'use strict';
 
 const xml = require('js2xmlparser');
+const xml2js = require('xml2js');
 
 function parse (projectName, object) {
   return xml.parse(projectName, object);
 }
 
-module.exports = { parse };
+function toJson (xml) {
+  return new Promise((resolve, reject) => {
+    xml2js.parseString(xml, (err, result) => {
+      if (err !== null) return reject(err);
+      resolve(result);
+    });
+  });
+}
+
+function toJsonArray (xmls) {
+  const jsons = [];
+  return new Promise((resolve, reject) => {
+    xmls.reduce((seq, xml) => {
+      return toJson(xml).then(json => {
+        jsons.push(json);
+      }).catch(e => {
+        reject(e);
+      });
+    }, Promise.resolve()).then(
+      () => resolve(jsons),
+      (e) => reject(e)
+    );
+  });
+}
+
+function merge (productName, licenceXmls) {
+  const product = {
+    name: productName,
+    projects: {
+      project: []
+    }
+  };
+  return new Promise((resolve, reject) => {
+    toJsonArray(licenceXmls).then(jsons => {
+      jsons.forEach(json => {
+        product.projects.project = product.projects.project.concat(json);
+      });
+    }).then(
+      () => resolve(parse(productName, product.projects)),
+      (e) => reject(e)
+    );
+  });
+}
+
+module.exports = {
+  'parse': parse,
+  'toJson': toJson,
+  'toJsonArray': toJsonArray,
+  'merge': merge
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,8 +1229,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -3273,6 +3272,11 @@
       "integrity": "sha1-cw/6Ikm98YMz7/5FsoYXPJxa0Lg=",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -3693,6 +3697,16 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
     },
     "xmlcreate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "js2xmlparser": "^3.0.0",
     "license-checker": "^11.0.0",
     "mustache": "^2.3.0",
+    "xml2js": "^0.4.17",
     "yargs": "^8.0.2"
   },
   "license": "Apache-2.0",

--- a/test/xml-test.js
+++ b/test/xml-test.js
@@ -9,3 +9,134 @@ test('Should parse object', (t) => {
   t.equal(obj, '<?xml version=\'1.0\'?>\n<something>\n    <one>1</one>\n    <two>2</two>\n</something>');
   t.end();
 });
+
+test('Should generate JSON from xml', (t) => {
+  t.plan(2);
+  const project1 = {
+    name: 'project1',
+    licenses: {
+      license: [
+        {name: 'projectDep1', version: '1.0', licenses: 'MIT', file: '...'}
+      ]
+    }
+  };
+  const projectXml = xml.parse('project1', project1.licenses);
+  xml.toJson(projectXml).then(result => {
+    t.ok(result.project1, 'should have project1 property');
+    t.ok(result.project1.license, 'should have licence array');
+    t.end();
+  }).catch(e => {
+    t.error(e);
+    t.fail();
+  });
+});
+
+test('Should throw error if invalid xml', (t) => {
+  t.plan(1);
+  xml.toJson('bogus').then(result => {
+    t.fail();
+  }).catch(e => {
+    t.ok(e, 'promise should be rejected is xml is invalid');
+    t.end();
+  });
+});
+
+test('Should generate JSON Array from xmls', (t) => {
+  t.plan(1);
+  const project1 = {
+    name: 'project1',
+    licenses: {
+      license: [
+        {name: 'projectDep1', version: '1.0', licenses: 'MIT', file: '...'}
+      ]
+    }
+  };
+  const project2 = {
+    name: 'project2',
+    licenses: {
+      license: [
+        {name: 'projectDep2', version: '2.0', licenses: 'AST', file: '...'}
+      ]
+    }
+  };
+  const xml1 = xml.parse('project1', project1.licenses);
+  const xml2 = xml.parse('project2', project2.licenses);
+  const xmls = [xml1, xml2];
+  xml.toJsonArray(xmls).then(jsons => {
+    t.equal(jsons.length, 2, 'should have created two json entries');
+    t.end();
+  }).catch(e => {
+    t.error(e);
+    t.fail();
+  });
+});
+
+test('Should generate JSON Array from xmls', (t) => {
+  t.plan(1);
+  const xmls = ['bogus1', 'bogus2'];
+  xml.toJsonArray(xmls).then(jsons => {
+    t.fail();
+  }).catch(e => {
+    t.ok(e, 'promise should have been rejected if xml were invalid');
+    t.end();
+  });
+});
+
+test('Should merge xmls', (t) => {
+  t.plan(1);
+  const project1 = {
+    name: 'project1',
+    licenses: {
+      license: [
+        {name: 'projectDep1', version: '1.0', licenses: 'MIT', file: '...'}
+      ]
+    }
+  };
+  const project2 = {
+    name: 'project2',
+    licenses: {
+      license: [
+        {name: 'projectDep2', version: '2.0', licenses: 'AST', file: '...'}
+      ]
+    }
+  };
+  const expected = String.raw`<?xml version='1.0'?>
+<productName>
+    <project>
+        <project1>
+            <license>
+                <name>projectDep1</name>
+                <version>1.0</version>
+                <licenses>MIT</licenses>
+                <file>...</file>
+            </license>
+        </project1>
+    </project>
+    <project>
+        <project2>
+            <license>
+                <name>projectDep2</name>
+                <version>2.0</version>
+                <licenses>AST</licenses>
+                <file>...</file>
+            </license>
+        </project2>
+    </project>
+</productName>`;
+  const xml1 = xml.parse('project1', project1.licenses);
+  const xml2 = xml.parse('project2', project2.licenses);
+  const xmls = [xml1, xml2];
+  const product = {
+    name: 'productName',
+    projects: {
+      project: []
+    }
+  };
+  xml.merge(product.name, xmls).then(result => {
+    t.equal(result, expected, 'merged xmls should follow correct structure');
+    t.end();
+  }).catch(e => {
+    t.error(e);
+    t.fail();
+  });
+});


### PR DESCRIPTION
To motivation for this commit is to be able to merge multiple
license.xml files for individual projects. For products that include
multiple projects this will allow for the creation of a single xml that
includes all the subproject licenses.