### PR TITLE
src: add warning when unknown license is found (#7)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -57,6 +57,8 @@ module.exports = function run (options) {
         }
       }
 
+      const unknown = require('../lib/unknown.js').check(project);
+
       const report = xml.parse(projectName, project.licenses);
       if (!options.silent) {
         console.log(report);
@@ -74,6 +76,8 @@ module.exports = function run (options) {
       printWarning(require('../lib/blacklist.js')(blacklist).check(project),
                   'BLACK-LISTED');
 
+      printWarning(unknown, 'UNKNOWN');
+
       if (options.html) {
         const html = require('../lib/html.js');
         html.parse(project).then(output => {
@@ -90,7 +94,7 @@ function printWarning (list, type) {
     list.forEach((license) => {
       console.log('name:', license.name,
         ', version:', license.version,
-        ', licenses:', license.licenses);
+        ', licenses:', license.license);
     });
     console.error(`========= WARNING ${type} LICENSES ==========`);
   }

--- a/lib/unknown.js
+++ b/lib/unknown.js
@@ -4,7 +4,7 @@ const unknown = 'UNKNOWN';
 
 module.exports.check = function (project) {
   return project.licenses.license.filter((license) => {
-    var found = false;
+    let found = false;
     if (unknownCheck(license.license)) {
       license.license = unknown;
       found = true;

--- a/lib/unknown.js
+++ b/lib/unknown.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const unknown = 'UNKNOWN';
+
+module.exports.check = function (project) {
+  return project.licenses.license.filter((license) => {
+    var found = false;
+    if (unknownCheck(license.license)) {
+      license.license = unknown;
+      found = true;
+    }
+    if (unknownCheck(license.file)) {
+      license.file = unknown;
+      found = true;
+    }
+    return found;
+  });
+};
+
+function unknownCheck (value) {
+  return value === undefined || value === '' || value.toUpperCase() === unknown;
+}

--- a/test/unknown-test.js
+++ b/test/unknown-test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const test = require('tape');
+
+test('Should warn if license is unknown', (t) => {
+  t.plan(1);
+  const project = {
+    name: 'testProject',
+    licenses: {
+      license: [
+        {name: 'test1', version: '1.0', license: 'MIT', file: 'something'},
+        {name: 'test2', version: '1.0', license: '', file: ''},
+        {name: 'test3', version: '1.0', license: 'unknown', file: ''},
+        {name: 'test4', version: '1.0', license: 'UNKNOWN', file: ''},
+        {name: 'test5', version: '1.2', license: undefined, file: undefined}
+      ]
+    }
+  };
+  const unknown = require('../lib/unknown.js').check(project);
+  t.equal(unknown.length, 4);
+  t.end();
+});


### PR DESCRIPTION
When a license has an unknown license (type or file) we want a warning
to be produced.

This commit adds a warning and also modifies the xml report to have an
UNKNOWN entry when this case occurs. Later we can add attributes to the
xml as required.