### PR TITLE
src: linking to the README instead parse it

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -109,8 +109,16 @@ function entry (info, npmVersion) {
   return entry;
 }
 
+/**
+ * This function will read the license file only if file found 
+ * or If it is not a README. If it is readme, it will return 
+ * the path to the README file, or N/A for other cases.
+ */
 function readLicenseFile (file) {
-  if (file) {
+  if (file.includes('README')) {
+    return file;
+  }
+  if (file && !file.includes('README')) {
     return fs.readFileSync(file, 'utf8');
   }
   return 'N/A';

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -110,9 +110,9 @@ function entry (info, npmVersion) {
 }
 
 /**
- * This function will read the license file only if file found 
- * or If it is not a README. If it is readme, it will return 
- * the path to the README file, or N/A for other cases.
+ * This function will read the license file only if file found
+ * or If it is not a README. If it is readme, it will return
+ * the path to the README file, or N/A for other cases
  */
 function readLicenseFile (file) {
   if (file.includes('README')) {


### PR DESCRIPTION
sample output 
```
    <license>
        <name>roi</name>
        <version>0.15.0</version>
        <license>Apache-2.0</license>
        <file>/home/hf/d/szero/node_modules/roi/README.md</file>
    </license>
```